### PR TITLE
Template engine option implemented

### DIFF
--- a/lib/trailblazer/generator/builder/view.rb
+++ b/lib/trailblazer/generator/builder/view.rb
@@ -8,13 +8,14 @@ class Trailblazer::Generator::Builder::View < Trailblazer::Operation
 
   def generate_actions!(options, params:)
     actions = params[:options]['actions'].split(',')
+    template_engine = params[:options]['template_engine']
     actions.each do |action|
-      generate_file(options, name: params[:name], action: action)
+      generate_file(options, name: params[:name], action: action, template_engine: template_engine)
     end
   end
 
   private
-    def generate_file(options, name:, action:)
+    def generate_file(options, name:, action:, template_engine:)
       model = Trailblazer::Generator::Cell.build_model(
         name: name, action: action
       )
@@ -22,7 +23,7 @@ class Trailblazer::Generator::Builder::View < Trailblazer::Operation
       content = Cell.(model, params)
 
       name = Trailblazer::Generator::Inflector.underscore(name)
-      path = File.join('app', 'concepts', name, 'view', "#{action}.erb")
+      path = File.join('app', 'concepts', name, 'view', "#{action}.#{template_engine}")
 
       Trailblazer::Generator::Output.new(path: path, content: content).save
     end

--- a/lib/trailblazer/generator/cli/generate/cell.rb
+++ b/lib/trailblazer/generator/cli/generate/cell.rb
@@ -4,10 +4,26 @@ module Trailblazer
       desc "cell NAME", "Generates cell file"
       long_desc <<-CELL_LONG_DESC
 
-      `generate cell` generate cell file
+      `generate cell` generate cell and view file
+
+      Actions Available:
+        * new
+        * show
+        * index (will generate item as well)
+        * edit
+        * generic (if name doesn't match above, is generic)
+
+      Template Engine for view:
+        * default => erb
+
+      Examples:
+        `generate cell BlogPost --actions index,foo --template_engine slim`
+
+        Will generate an index, item and foo cell files and the corrisponding template using slim
 
       CELL_LONG_DESC
       options actions: :required
+      option :template_engine, default: "erb"
       def cell(name)
         Trailblazer::Generator::Builder::Cell.(name: name, options: options)
       end


### PR DESCRIPTION
`--template_engine` added as option for `generate cell`.
It simply changes the extension of the view file having `erb` as default.