### PR TITLE
No output file during test for Cell and View

### DIFF
--- a/lib/trailblazer/generator/builder/cell.rb
+++ b/lib/trailblazer/generator/builder/cell.rb
@@ -4,14 +4,28 @@ class Trailblazer::Generator::Builder::Cell < Trailblazer::Operation
 
   step Trailblazer::Generator::Macro::ValidateClassName()
   step :generate_actions!
+  step :create_files!
   step :generate_views!
   failure Trailblazer::Generator::Macro::Failure()
 
   def generate_actions!(options, params:)
     actions = params[:options]['actions'].split(',')
+    params["cell_result"] = {"files_content" => [], "files_path" => []}
     actions.each do |action|
-      generate_file(options, name: params[:name], action: action)
-      generate_file(options, name: params[:name], action: 'item') if action == 'Index'
+      params = generate_file(options, params: params, action: action)
+      params = generate_file(options, params: params, action: 'item') if action == 'Index'
+    end
+  end
+
+  def create_files!(options, params:)
+    debug = (params[:options]["debug"] ||= false)
+    return true if debug
+
+    contents = params["cell_result"]["files_content"]
+    paths = params["cell_result"]["files_path"]
+
+    contents.zip(paths).each do |content, path|
+      Trailblazer::Generator::Output.new(path: path, content: content).save
     end
   end
 
@@ -22,21 +36,24 @@ class Trailblazer::Generator::Builder::Cell < Trailblazer::Operation
       actions << ',item'
       options_dup['actions'] = actions
     end
-    Trailblazer::Generator::Builder::View.(name: params[:name], options: options_dup)
+    result = Trailblazer::Generator::Builder::View.(name: params[:name], options: options_dup)
+    params["view_result"] = result["params"]["view_result"]
     true
   end
 
   private
-    def generate_file(options, name:, action:)
+    def generate_file(options, params:, action:)
       model = Trailblazer::Generator::Cell.build_model(
-        name: name, action: action
+        name: params[:name], action: action
       )
-      params = options['params'][:options]
-      content = Cell.(model, params)
+      content = Cell.(model, params[:options])
 
-      name = Trailblazer::Generator::Inflector.underscore(name)
-      path = File.join('app', 'concepts', name, 'cell', "#{action}.rb")
+      params["cell_result"]["files_content"] << content.show
 
-      Trailblazer::Generator::Output.new(path: path, content: content).save
+      name = Trailblazer::Generator::Inflector.underscore(params[:name])
+      path = File.join('app', 'concepts', name, 'cell', "#{action.downcase}.rb")
+
+      params["cell_result"]["files_path"] << path
+      return params
     end
 end

--- a/lib/trailblazer/generator/builder/cell.rb
+++ b/lib/trailblazer/generator/builder/cell.rb
@@ -8,28 +8,27 @@ class Trailblazer::Generator::Builder::Cell < Trailblazer::Operation
   step :generate_views!
   failure Trailblazer::Generator::Macro::Failure()
 
-  def generate_actions!(options, params:)
+  def generate_actions!(options, params:, **)
     actions = params[:options]['actions'].split(',')
-    params["cell_result"] = {"files_content" => [], "files_path" => []}
+    options["cell_result"] = {"files_content" => [], "files_path" => []}
     actions.each do |action|
-      params = generate_file(options, params: params, action: action)
-      params = generate_file(options, params: params, action: 'item') if action == 'Index'
+      options["cell_result"] = generate_file(options, params: params, action: action)
+      options["cell_result"] = generate_file(options, params: params, action: 'item') if action == 'Index'
     end
   end
 
-  def create_files!(options, params:)
+  def create_files!(options, params:, **)
     debug = (params[:options]["debug"] ||= false)
     return true if debug
-
-    contents = params["cell_result"]["files_content"]
-    paths = params["cell_result"]["files_path"]
+    contents = options["cell_result"]["files_content"]
+    paths = options["cell_result"]["files_path"]
 
     contents.zip(paths).each do |content, path|
       Trailblazer::Generator::Output.new(path: path, content: content).save
     end
   end
 
-  def generate_views!(options, params:)
+  def generate_views!(options, params:, **)
     options_dup = params[:options].dup
     actions = params[:options]['actions'].dup
     if actions.match /index/i
@@ -37,7 +36,7 @@ class Trailblazer::Generator::Builder::Cell < Trailblazer::Operation
       options_dup['actions'] = actions
     end
     result = Trailblazer::Generator::Builder::View.(name: params[:name], options: options_dup)
-    params["view_result"] = result["params"]["view_result"]
+    options["view_result"] = result["view_result"]
     true
   end
 
@@ -48,12 +47,12 @@ class Trailblazer::Generator::Builder::Cell < Trailblazer::Operation
       )
       content = Cell.(model, params[:options])
 
-      params["cell_result"]["files_content"] << content.show
+      options["cell_result"]["files_content"] << content.show
 
       name = Trailblazer::Generator::Inflector.underscore(params[:name])
       path = File.join('app', 'concepts', name, 'cell', "#{action.downcase}.rb")
 
-      params["cell_result"]["files_path"] << path
-      return params
+      options["cell_result"]["files_path"] << path
+      return options["cell_result"]
     end
 end

--- a/lib/trailblazer/generator/builder/view.rb
+++ b/lib/trailblazer/generator/builder/view.rb
@@ -4,26 +4,43 @@ class Trailblazer::Generator::Builder::View < Trailblazer::Operation
 
   step Trailblazer::Generator::Macro::ValidateClassName()
   step :generate_actions!
+  step :create_files!
   failure Trailblazer::Generator::Macro::Failure()
 
   def generate_actions!(options, params:)
     actions = params[:options]['actions'].split(',')
+    params["view_result"] = {"files_content" => [], "files_path" => []}
     actions.each do |action|
-      generate_file(options, name: params[:name], action: action)
+      generate_file(options, params: params, action: action)
+    end
+  end
+
+  def create_files!(options, params:)
+    debug = (params[:options]["debug"] ||= false)
+    return true if debug
+
+    contents = params["view_result"]["files_content"]
+    paths = params["view_result"]["files_path"]
+
+    contents.zip(paths).each do |content, path|
+      Trailblazer::Generator::Output.new(path: path, content: content).save
     end
   end
 
   private
-    def generate_file(options, name:, action:)
+    def generate_file(options, params:, action:)
       model = Trailblazer::Generator::Cell.build_model(
-        name: name, action: action
+        name: params[:name], action: action
       )
-      params = options['params'][:options]
-      content = Cell.(model, params)
+      content = Cell.(model, params[:options])
 
-      name = Trailblazer::Generator::Inflector.underscore(name)
-      path = File.join('app', 'concepts', name, 'view', "#{action}.erb")
+      params["view_result"]["files_content"] << content.show
 
-      Trailblazer::Generator::Output.new(path: path, content: content).save
+      name = Trailblazer::Generator::Inflector.underscore(params[:name])
+      path = File.join('app', 'concepts', name, 'view', "#{action.downcase}.erb")
+
+      params["view_result"]["files_path"] << path
+
+      return params
     end
 end

--- a/lib/trailblazer/generator/builder/view.rb
+++ b/lib/trailblazer/generator/builder/view.rb
@@ -7,20 +7,20 @@ class Trailblazer::Generator::Builder::View < Trailblazer::Operation
   step :create_files!
   failure Trailblazer::Generator::Macro::Failure()
 
-  def generate_actions!(options, params:)
+  def generate_actions!(options, params:, **)
     actions = params[:options]['actions'].split(',')
-    params["view_result"] = {"files_content" => [], "files_path" => []}
+    options["view_result"] = {"files_content" => [], "files_path" => []}
     actions.each do |action|
-      generate_file(options, params: params, action: action)
+      options["view_result"] = generate_file(options, params: params, action: action)
     end
   end
 
-  def create_files!(options, params:)
+  def create_files!(options, params:, **)
     debug = (params[:options]["debug"] ||= false)
     return true if debug
 
-    contents = params["view_result"]["files_content"]
-    paths = params["view_result"]["files_path"]
+    contents = options["view_result"]["files_content"]
+    paths = options["view_result"]["files_path"]
 
     contents.zip(paths).each do |content, path|
       Trailblazer::Generator::Output.new(path: path, content: content).save
@@ -34,13 +34,13 @@ class Trailblazer::Generator::Builder::View < Trailblazer::Operation
       )
       content = Cell.(model, params[:options])
 
-      params["view_result"]["files_content"] << content.show
+      options["view_result"]["files_content"] << content.show
 
       name = Trailblazer::Generator::Inflector.underscore(params[:name])
       path = File.join('app', 'concepts', name, 'view', "#{action.downcase}.erb")
 
-      params["view_result"]["files_path"] << path
+      options["view_result"]["files_path"] << path
 
-      return params
+      return options["view_result"]
     end
 end

--- a/test/trailblazer/generator/builder/cell_test.rb
+++ b/test/trailblazer/generator/builder/cell_test.rb
@@ -80,26 +80,25 @@ class Trailblazer::Generator::Builder::CellTest < Minitest::Test
                 ]
 
     result = Trailblazer::Generator::Builder::Cell.(name: "BlogPost", options: {"actions" => "new,edit,show,index,custom", "debug" => true})
-
     # cells files
-    cell_files.zip(result["params"]["cell_result"]["files_content"]).each do |cell_file, cell_file_result|
+    cell_files.zip(result["cell_result"]["files_content"]).each do |cell_file, cell_file_result|
       assert_equal cell_file, cell_file_result
     end
 
     # cells paths
-    cell_paths.zip(result["params"]["cell_result"]["files_path"]).each do |cell_path, cell_path_result|
+    cell_paths.zip(result["cell_result"]["files_path"]).each do |cell_path, cell_path_result|
       assert_equal cell_path, cell_path_result
     end
 
     # view files
     actions = result["params"][:options]["actions"].split(",")
-    view_files_result = result["params"]["view_result"]["files_content"]
+    view_files_result = result["view_result"]["files_content"]
     actions.zip(view_files_result).each do |action, view_file_result|
       assert_equal view_file(action), view_file_result
     end
 
     # view paths
-    view_paths.zip(result["params"]["view_result"]["files_path"]).each do |view_path, view_path_result|
+    view_paths.zip(result["view_result"]["files_path"]).each do |view_path, view_path_result|
       assert_equal view_path, view_path_result
     end
 

--- a/test/trailblazer/generator/builder/cell_test.rb
+++ b/test/trailblazer/generator/builder/cell_test.rb
@@ -52,30 +52,56 @@ class Trailblazer::Generator::Builder::CellTest < Minitest::Test
       end
     EOF
 
-    def view_file(model, model_underscore, action)
+    cell_files = [str_cell_new, str_cell_edit, str_cell_show, str_cell_index, str_cell_item, str_cell_custom]
+
+    cell_paths = [
+                    "app/concepts/blog_post/cell/new.rb",
+                    "app/concepts/blog_post/cell/edit.rb",
+                    "app/concepts/blog_post/cell/show.rb",
+                    "app/concepts/blog_post/cell/index.rb",
+                    "app/concepts/blog_post/cell/item.rb",
+                    "app/concepts/blog_post/cell/custom.rb"
+                  ]
+
+    def view_file(action)
       <<~EOF
-        <h1>#{model}##{action}</h1>
-        <p>Find me in app/concepts/#{model_underscore}/view/#{action}.erb</p>
+        <h1>BlogPost##{action}</h1>
+        <p>Find me in app/concepts/blog_post/view/#{action}.erb</p>
       EOF
     end
 
-    Trailblazer::Generator::Builder::Cell.(name: "BlogPost", options: {"actions" => "new,edit,show,index,custom"})
+    view_paths = [
+                  "app/concepts/blog_post/view/new.erb",
+                  "app/concepts/blog_post/view/edit.erb",
+                  "app/concepts/blog_post/view/show.erb",
+                  "app/concepts/blog_post/view/index.erb",
+                  "app/concepts/blog_post/view/custom.erb",
+                  "app/concepts/blog_post/view/item.erb"
+                ]
+
+    result = Trailblazer::Generator::Builder::Cell.(name: "BlogPost", options: {"actions" => "new,edit,show,index,custom", "debug" => true})
 
     # cells files
-    assert_equal str_cell_new, File.read('app/concepts/blog_post/cell/new.rb')
-    assert_equal str_cell_edit, File.read('app/concepts/blog_post/cell/edit.rb')
-    assert_equal str_cell_item, File.read('app/concepts/blog_post/cell/item.rb')
-    assert_equal str_cell_index, File.read('app/concepts/blog_post/cell/index.rb')
-    assert_equal str_cell_show, File.read('app/concepts/blog_post/cell/show.rb')
-    assert_equal str_cell_custom, File.read('app/concepts/blog_post/cell/custom.rb')
+    cell_files.zip(result["params"]["cell_result"]["files_content"]).each do |cell_file, cell_file_result|
+      assert_equal cell_file, cell_file_result
+    end
+
+    # cells paths
+    cell_paths.zip(result["params"]["cell_result"]["files_path"]).each do |cell_path, cell_path_result|
+      assert_equal cell_path, cell_path_result
+    end
 
     # view files
-    assert_equal view_file("BlogPost", "blog_post", "new"), File.read('app/concepts/blog_post/view/new.erb')
-    assert_equal view_file("BlogPost", "blog_post", "edit"), File.read('app/concepts/blog_post/view/edit.erb')
-    assert_equal view_file("BlogPost", "blog_post", "index"), File.read('app/concepts/blog_post/view/index.erb')
-    assert_equal view_file("BlogPost", "blog_post", "item"), File.read('app/concepts/blog_post/view/item.erb')
-    assert_equal view_file("BlogPost", "blog_post", "show"), File.read('app/concepts/blog_post/view/show.erb')
-    assert_equal view_file("BlogPost", "blog_post", "custom"), File.read('app/concepts/blog_post/view/custom.erb')
+    actions = result["params"][:options]["actions"].split(",")
+    view_files_result = result["params"]["view_result"]["files_content"]
+    actions.zip(view_files_result).each do |action, view_file_result|
+      assert_equal view_file(action), view_file_result
+    end
+
+    # view paths
+    view_paths.zip(result["params"]["view_result"]["files_path"]).each do |view_path, view_path_result|
+      assert_equal view_path, view_path_result
+    end
 
   end
 


### PR DESCRIPTION
Ciao,
I have changed the `generate_file` method which is creating the hash `cell_result` into `params` to first have 2 arrays with the contents and the paths of the files. 
Then in the `create_files!` step if the flag debug is false the `Trailblazer::Generator::Output` method is called an the file are actually created otherwise the contents and the paths are in the operation result object in this way is possible to test them without creating the files.