### PR TITLE
Less Redundancy

### DIFF
--- a/lib/trailblazer/generator/builder/contract.rb
+++ b/lib/trailblazer/generator/builder/contract.rb
@@ -1,33 +1,31 @@
-class Trailblazer::Generator::Builder::Contract < Trailblazer::Operation
+require_relative 'operation.rb'
+
+class Trailblazer::Generator::Builder::Contract < Trailblazer::Generator::Builder::Operation
   class Cell < Trailblazer::Generator::Cell
+
     def properties
       return [] unless options.key?("properties")
       options["properties"]
     end
   end
 
-  step Trailblazer::Generator::Macro::ValidateClassName()
-  step :generate_actions!
-  failure Trailblazer::Generator::Macro::Failure()
+  # step Trailblazer::Generator::Macro::ValidateClassName()
+  # step :generate_actions!
+  # failure Trailblazer::Generator::Macro::Failure()
 
-  def generate_actions!(options, params:)
-    actions = params[:options]['actions'].split(',')
-    actions.each do |action|
-      generate_file(options, name: params[:name], action: action)
-    end
-  end
+  # def generate_actions!(options, params:)
+  #   actions = params[:options]['actions'].split(',')
+  #   actions.each do |action|
+  #     generate_file(options, name: params[:name], action: action)
+  #   end
+  # end
 
   private
-    def generate_file(options, name:, action:)
+    def generate_data(options, name:, action:)
       model = Trailblazer::Generator::Cell.build_model(
         name: name, action: action
       )
       params = options['params'][:options]
-      content = Cell.(model, params)
-
-      name = Trailblazer::Generator::Inflector.underscore(name)
-      path = File.join('app', 'concepts', name, 'contract', "#{action}.rb")
-
-      Trailblazer::Generator::Output.new(path: path, content: content).save
+      options["content"] = Cell.(model, params)
     end
 end

--- a/lib/trailblazer/generator/builder/operation.rb
+++ b/lib/trailblazer/generator/builder/operation.rb
@@ -9,21 +9,24 @@ class Trailblazer::Generator::Builder::Operation < Trailblazer::Operation
   def generate_actions!(options, params:)
     actions = params[:options]['actions'].split(',')
     actions.each do |action|
-      generate_file(options, name: params[:name], action: action)
+      generate_data(options, name: params[:name], action: action)
+      create_file(options, name: params[:name], action: action)
     end
   end
 
   private
-    def generate_file(options, name:, action:)
+    def generate_data(options, name:, action:)
       model = Trailblazer::Generator::Cell.build_model(
         name: name, action: action
       )
       params = options['params'][:options]
-      content = Cell.(model, params)
+      options["content"] = Cell.(model, params)
+    end
 
+    def create_file(options, name:, action:)
       name = Trailblazer::Generator::Inflector.underscore(name)
-      path = File.join('app', 'concepts', name, 'operation', "#{action}.rb")
+      path = File.join('app', 'concepts', name, options["params"][:command], "#{action}.rb")
 
-      Trailblazer::Generator::Output.new(path: path, content: content).save
+      Trailblazer::Generator::Output.new(path: path, content: options["content"]).save
     end
 end

--- a/lib/trailblazer/generator/cli/generate/contract.rb
+++ b/lib/trailblazer/generator/cli/generate/contract.rb
@@ -10,7 +10,7 @@ module Trailblazer
       options actions: :required
       options properties: :array
       def contract(name)
-        Trailblazer::Generator::Builder::Contract.(name: name, options: options)
+        Trailblazer::Generator::Builder::Contract.(name: name, options: options, command: 'contract')
       end
     end
   end

--- a/lib/trailblazer/generator/cli/generate/operation.rb
+++ b/lib/trailblazer/generator/cli/generate/operation.rb
@@ -22,7 +22,7 @@ module Trailblazer
       OPERATION_LONG_DESC
       options actions: :required
       def operation(name)
-        Trailblazer::Generator::Builder::Operation.(name: name, options: options)
+        Trailblazer::Generator::Builder::Operation.(name: name, options: options, command: 'operation')
       end
     end
   end

--- a/test/trailblazer/generator/builder/contract_test.rb
+++ b/test/trailblazer/generator/builder/contract_test.rb
@@ -18,7 +18,7 @@ class Trailblazer::Generator::Builder::ContractTest < Minitest::Test
     EOF
 
 
-    Trailblazer::Generator::Builder::Contract.(name: "BlogPost", options: {"actions" => "new,edit", "properties" => []})
+    Trailblazer::Generator::Builder::Contract.(name: "BlogPost", options: {"actions" => "new,edit", "properties" => []}, command: 'contract')
 
     assert_equal str_contract_new, File.read('app/concepts/blog_post/contract/new.rb')
     assert_equal str_contract_edit, File.read('app/concepts/blog_post/contract/edit.rb')
@@ -36,7 +36,7 @@ class Trailblazer::Generator::Builder::ContractTest < Minitest::Test
     EOF
 
 
-    Trailblazer::Generator::Builder::Contract.(name: "BlogPost", options: {"actions" => "edit", "properties" => ["title", "subtitle", "body"]})
+    Trailblazer::Generator::Builder::Contract.(name: "BlogPost", options: {"actions" => "edit", "properties" => ["title", "subtitle", "body"]}, command: 'contract')
 
     assert_equal str, File.read('app/concepts/blog_post/contract/edit.rb')
   end

--- a/test/trailblazer/generator/builder/operation_test.rb
+++ b/test/trailblazer/generator/builder/operation_test.rb
@@ -56,7 +56,7 @@ class Trailblazer::Generator::Builder::OperationTest < Minitest::Test
       end
     EOF
 
-    Trailblazer::Generator::Builder::Operation.(name: "Blog", options: {"actions" => "create,update,index,show,delete"})
+    Trailblazer::Generator::Builder::Operation.(name: "Blog", options: {"actions" => "create,update,index,show,delete"}, command: 'operation')
 
     assert_equal str_op_create, File.read('app/concepts/blog/operation/create.rb')
     assert_equal str_op_update, File.read('app/concepts/blog/operation/update.rb')
@@ -74,7 +74,7 @@ class Trailblazer::Generator::Builder::OperationTest < Minitest::Test
     EOF
 
 
-    Trailblazer::Generator::Builder::Operation.(name: "BlogPost", options: {present: false, "actions" => "custom"})
+    Trailblazer::Generator::Builder::Operation.(name: "BlogPost", options: {present: false, "actions" => "custom"}, command: 'operation')
 
     assert_equal str, File.read('app/concepts/blog_post/operation/custom.rb')
   end
@@ -98,7 +98,7 @@ class Trailblazer::Generator::Builder::OperationTest < Minitest::Test
     EOF
 
 
-    Trailblazer::Generator::Builder::Operation.(name: "BlogPost", options: {present: true, "actions" => "custom"})
+    Trailblazer::Generator::Builder::Operation.(name: "BlogPost", options: {present: true, "actions" => "custom"}, command: 'operation')
 
     assert_equal str, File.read('app/concepts/blog_post/operation/custom.rb')
   end


### PR DESCRIPTION
Ciao,
All the operations are really really similar apart of few details so why we don't inherit from the simplest one and then override or add new step where we need?
Here what I have changed just for `operation` and `contract`:
1) `generate_file` is divided in 2 methods: `generate_data` which needs to be called in every Operation otherwise the `view_paths` and the `controller_path` in the Cell class won't work **and** `create_file` which can be inherited (probably not for view)
2) added `command` as argument in the Thor classes in order to use it in the `create_file` method
3) the `Contract` class is inherited from `Operation`

Probably there is a way to inherit the `generate_data` method as well, just need to find a way to set the correct `TemplateFile` for `Cell`.

What do you guys think?